### PR TITLE
Adding Anrop TvT ACE3 + STHUD + loadouts to templates

### DIFF
--- a/templates/templates.json
+++ b/templates/templates.json
@@ -64,6 +64,17 @@
     ]
   },
   {
+    "title": "Anrop TvT ACE3 + STHUD + loadouts",
+    "mods": [
+      "@ace3",
+      "@ace3_particles",
+      "@cba_a3",
+      "@shacktac_user_interface",
+      "@task_force_radio_dev",
+      "@zsn_loadouts"
+    ]
+  },
+  {
     "title": "CUP Terrain Pack",
     "mods": [
       "@cup_terrains_core",


### PR DESCRIPTION
**When merged this pull request will:**

- Add a template for TvT missions made by members of Anrop containing the following mods
  - [x] @ace_3
  - [x] @cba_a3
  - [x] @ace3_particles
  - [x] @shacktac_user_interface
  - [x] @task_force_radio_dev
  - [x] @zsn_loadouts
