### PR TITLE
Add FNF Optional Clientside Mods as template

### DIFF
--- a/templates/index.js
+++ b/templates/index.js
@@ -13,6 +13,7 @@ app.get('/', (req, res) => {
       afisync(arma3sync),
       steamWorkshop.collection('Arma Sweden', 457453269, arma3sync),
       steamWorkshop.collection('FNF - Required Mods', 2905664671, arma3sync)
+      steamWorkshop.collection('FNF - Optional Clientside Mods', 1551648858, arma3sync)
     ]))
     .then((dynamicTemplates) => {
       const sortedTemplates = dynamicTemplates


### PR DESCRIPTION
This pull serves to create a template allowing users to select whitelisted clientside mods for FNF from a template which they can load into Arma3Sync.